### PR TITLE
削除機能実装

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -49,6 +49,16 @@ class PrototypesController < ApplicationController
     end  
   end
 
+  def destroy
+    prototype = Prototype.find(params[:id])
+    if user_signed_in? && current_user.id == prototype.user_id
+      prototype.destroy
+      redirect_to root_path
+    else
+      redirect_to new_user_session_path
+    end  
+  end  
+
   private
   
   def prototype_params

--- a/app/views/prototypes/show.html.erb
+++ b/app/views/prototypes/show.html.erb
@@ -7,8 +7,8 @@
       <%= link_to "by #{@user.name}", root_path, class: :prototype__user %>
       <% if user_signed_in? && current_user.id == @prototype.user_id %><%# プロトタイプの投稿者とログインしているユーザーが同じであれば以下を表示する %>
         <div class="prototype__manage">
-          <%= link_to "編集する", root_path, class: :prototype__btn %>
-          <%= link_to "削除する", root_path, class: :prototype__btn %>
+          <%= link_to "編集する", edit_prototype_path, class: :prototype__btn %>
+          <%= link_to "削除する", prototype_path(@prototype.id), data: { turbo_method: :delete }, class: :prototype__btn %>
         </div>
       <% end %><%# // プロトタイプの投稿者とログインしているユーザーが同じであれば上記を表示する %>
       <div class="prototype__image">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
   root to: "prototypes#index"
-  resources :prototypes, only: [:index, :new, :create, :show, :edit, :update]
+  resources :prototypes, only: [:index, :new, :create, :show, :edit, :update, :destroy]
   resources :users, only: :show
 end


### PR DESCRIPTION
#What
プロトタイプ情報削除機能実装

#Why
プロトタイプを投稿者自身が削除できる機能を持たせるため。

ログイン状態の投稿者のみ、詳細ページの削除ボタンを押すと、投稿したプロトタイプを削除できる動画
https://gyazo.com/e8a1b5eba46492696d5a3d8118ead2fd